### PR TITLE
Add prettier plugin and config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,26 @@
+const prettierConfig = require('./prettier.config')
+
 module.exports = {
-  extends: 'standard',
+  plugins: ['prettier'],
+  extends: [
+    'standard',
+    // These should go last since they disable all formatting-related lints.
+    'plugin:prettier/recommended',
+    'prettier/react',
+    'prettier/standard',
+  ],
   rules: {
     // Disabled so we don't have to change chai assertions.
     // See: https://github.com/standard/standard/issues/690
-    'no-unused-expressions': 'off'
-  }
+    'no-unused-expressions': 'off',
+
+    'prettier/prettier': [
+      'error',
+      prettierConfig,
+      {
+        // Rule should not be affected by a Prettier configuration file.
+        usePrettierrc: false,
+      },
+    ],
+  },
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "repository": "https://github.com/vend/eslint-config",
   "license": "MIT",
-  "dependencies": {
-    "eslint-config-standard": "^12.0.0"
+  "peerDependencies": {
+    "eslint-config-standard": "^12.0.0",
+    "eslint-config-prettier": "^4.1.0",
+    "eslint-plugin-prettier": "^3.0.1"
   }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  semi: false,
+  singleQuote: true,
+  trailingComma: 'es5',
+  parser: 'typescript',
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,3 @@
 # yarn lockfile v1
 
 
-eslint-config-standard@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz#638b4c65db0bd5a41319f96bba1f15ddad2107d9"
-  integrity sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==


### PR DESCRIPTION
![](https://media1.giphy.com/media/xUOxfd7g8jnaGEDtDi/giphy.gif)

The configuration is the same as monocle's.

Also format code in this repo according to our prettier rules.

Finally, move dependencies to peerDependencies. This is how eslint shared configs have to work, unfortunately: https://github.com/eslint/eslint/issues/2518 (Technically hoisting would probably let us get away with just having `dependencies`, but it could also mysteriously stop working one day for any variety of reasons.)