### PR TITLE
Enable TypeScript and add tslint:recommended-inspired rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn-error.log

--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ module.exports = {
       // Prefer ES6-style imports over 'require'.
       '@typescript-eslint/no-var-requires': 'error',
 
-      // Prefer functiopn types over callable interface types with no other members.
+      // Prefer function types over callable interface types with no other members.
       '@typescript-eslint/prefer-function-type': 'error',
 
       // Prefer interfaces over type literals (type T = { ... }).

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const prettierConfig = require('./prettier.config')
 
 module.exports = {
-  plugins: ['prettier'],
+  plugins: ['@typescript-eslint', 'prettier'],
   extends: [
     'standard',
     'standard-react',
@@ -11,13 +11,47 @@ module.exports = {
     'prettier/standard',
   ],
   rules: {
+    // Prefer () => 0 over () => { return 0 }.
+    'arrow-body-style': 'error',
+
+    // Prefer foo.bar over foo['bar'].
+    'dot-notation': 'error',
+
+    // Disallow use of the console object, such as console.log.
+    'no-console': 'error',
+
+    // Disallow empty conditional and loop bodies.
+    'no-empty': 'error',
+
     // Disabled so we don't have to change chai assertions.
     // See: https://github.com/standard/standard/issues/690
     'no-unused-expressions': 'off',
 
-    // We use TypeScript so don't usually need PropTypes.
-    'react/prop-types': 'off',
+    // Don't allow unused labels.
+    'no-unused-labels': 'off',
 
+    // Disallow the 'var' keyword.
+    'no-var': 'error',
+
+    // Prefer ES6 shorthand notation in object literals.
+    'object-shorthand': 'error',
+
+    // Make variables const when possible.
+    'prefer-const': 'error',
+
+    // Require the radix argument to parseInt to avoid unintentionally allowing hex or octal.
+    radix: 'error',
+
+    // Require PascalCased class names.
+    '@typescript-eslint/class-name-casing': 'error',
+
+    // Have a convention around import order.
+    'import/order': 'error',
+
+    // Prefer arrow functions when passing callbacks.
+    'prefer-arrow-callback': 'error',
+
+    // Require that code be formatted according to Prettier rules.
     'prettier/prettier': [
       'error',
       prettierConfig,
@@ -26,5 +60,130 @@ module.exports = {
         usePrettierrc: false,
       },
     ],
+
+    // We use TypeScript so don't usually need PropTypes.
+    'react/prop-types': 'off',
+  },
+
+  // TypeScript-specific rules. Somewhat inspired by tslint:recommended.
+  overrides: {
+    files: ['**/*.ts', '**/*.tsx'],
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+      ecmaVersion: 2018,
+      sourceType: 'module',
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+
+    rules: {
+      // Require overloads to be grouped together
+      '@typescript-eslint/adjacent-overload-signatures': 'error',
+
+      // Use T[] over Array<T> for simple types
+      '@typescript-eslint/array-type': ['error', 'array-simple'],
+
+      // Prevent use of certain types that are almost always mistakes.
+      '@typescript-eslint/ban-types': [
+        'error',
+        {
+          types: {
+            Boolean: {
+              fixWith: 'boolean',
+              message:
+                'Avoid using the `Boolean` type. Did you mean `boolean`?',
+            },
+            Function: {
+              message:
+                'Avoid using the `Function` type. Prefer a specific function type like `() => void`.',
+            },
+            Number: {
+              fixWith: 'number',
+              message: 'Avoid using the `Number` type. Did you mean `number`?',
+            },
+            Object: {
+              message: 'Avoid using the `Object` type. Did you mean `object`?',
+            },
+            String: {
+              fixWith: 'string',
+              message: 'Avoid using the `String` type. Did you mean `string`?',
+            },
+            Symbol: {
+              fixWith: 'symbol',
+              message: 'Avoid using the `Symbol` type. Did you mean `symbol`?',
+            },
+          },
+        },
+      ],
+
+      // Require camelCase names, except for property names.
+      camelcase: 'off',
+      '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
+
+      // TODO: enable once a new typescript-eslint release is cut and we can exclude constructors, like TSLint.
+      // Require fields and methods to be explicitly labeled public, private, or protected.
+      // '@typescript-eslint/explicit-member-accessibility': 'error',
+
+      // Require consistent ordering of fields, methods, and constructors.
+      '@typescript-eslint/member-ordering': [
+        'error',
+        {
+          default: [
+            'public-static-field',
+            'public-static-method',
+            'protected-static-field',
+            'protected-static-method',
+            'private-static-field',
+            'private-static-method',
+            'instance-field',
+            'constructor',
+            'instance-method',
+          ],
+        },
+      ],
+
+      // Require 'as' type assertions.
+      '@typescript-eslint/no-angle-bracket-type-assertion': 'error',
+
+      // Disallow empty interfaces, which are not useful.
+      '@typescript-eslint/no-empty-interface': 'error',
+
+      // Disallow invalid declarations of constructors on interfaces and 'new' methods on classes.
+      '@typescript-eslint/no-misused-new': 'error',
+
+      // Don't allow modules or namespaces, except in declaration files.
+      '@typescript-eslint/no-namespace': [
+        'error',
+        { allowDefinitionFiles: true },
+      ],
+
+      // Use import instead of triple-slash reference comments.
+      '@typescript-eslint/no-triple-slash-reference': 'error',
+
+      // TypeScript-aware unused variable rule.
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          // Allow unused function arguments
+          args: 'none',
+          // Allow destructuring like { a, ...b } = obj even if a is unused, to allow omitting fields.
+          ignoreRestSiblings: true,
+        },
+      ],
+
+      // Prefer ES6-style imports over 'require'.
+      '@typescript-eslint/no-var-requires': 'error',
+
+      // Prefer functiopn types over callable interface types with no other members.
+      '@typescript-eslint/prefer-function-type': 'error',
+
+      // Prefer interfaces over type literals (type T = { ... }).
+      '@typescript-eslint/prefer-interface': 'error',
+
+      // Warn when two overloads could be combined into one.
+      '@typescript-eslint/unified-signatures': 'error',
+    },
   },
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/vend/eslint-config",
   "license": "MIT",
   "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^1.6.0",
     "eslint-config-prettier": "^4.1.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-config-standard-react": "^7.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,81 @@
 # yarn lockfile v1
 
 
-eslint-config-standard-jsx@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz#90c9aa16ac2c4f8970c13fc7efc608bacd02da70"
-  integrity sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==
-
-eslint-config-standard-react@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard-react/-/eslint-config-standard-react-7.0.2.tgz#80b51a0e0c371ef987679ee134768457a5b6db92"
-  integrity sha512-Zv/vubIfrwx4IbRXAggRjaswLXKdfFeuGfN365cVTaRmfpAy/7dIxMvJRZkUT99zEx8FOjTXL0KC4psfDjK/+w==
+"@typescript-eslint/eslint-plugin@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.6.0.tgz#a5ff3128c692393fb16efa403ec7c8a5593dab0f"
+  integrity sha512-U224c29E2lo861TQZs6GSmyC0OYeRNg6bE9UVIiFBxN2MlA0nq2dCrgIVyyRbC05UOcrgf2Wk/CF2gGOPQKUSQ==
   dependencies:
-    eslint-config-standard-jsx "^6.0.1"
+    "@typescript-eslint/parser" "1.6.0"
+    "@typescript-eslint/typescript-estree" "1.6.0"
+    requireindex "^1.2.0"
+    tsutils "^3.7.0"
+
+"@typescript-eslint/parser@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.6.0.tgz#f01189c8b90848e3b8e45a6cdad27870529d1804"
+  integrity sha512-VB9xmSbfafI+/kI4gUK3PfrkGmrJQfh0N4EScT1gZXSZyUxpsBirPL99EWZg9MmPG0pzq/gMtgkk7/rAHj4aQw==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "1.6.0"
+    eslint-scope "^4.0.0"
+    eslint-visitor-keys "^1.0.0"
+
+"@typescript-eslint/typescript-estree@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.6.0.tgz#6cf43a07fee08b8eb52e4513b428c8cdc9751ef0"
+  integrity sha512-A4CanUwfaG4oXobD5y7EXbsOHjCwn8tj1RDd820etpPAjH+Icjc2K9e/DQM1Hac5zH2BSy+u6bjvvF2wwREvYA==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
+
+eslint-scope@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+
+esrecurse@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+  dependencies:
+    estraverse "^4.1.0"
+
+estraverse@^4.1.0, estraverse@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+  integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
+
+tslib@^1.8.1:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tsutils@^3.7.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.10.0.tgz#6f1c95c94606e098592b0dff06590cf9659227d6"
+  integrity sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==
+  dependencies:
+    tslib "^1.8.1"


### PR DESCRIPTION
![](https://media1.giphy.com/media/8JCZV0rs29YVG/giphy.gif)

This uses the `@typescript-eslint` plugin and parser.

Note that some of these rules are enabled for JS as well, since it makes sense to keep our JS in line with our TS as much as reasonably possible.

Notable omissions:
* `max-class-files` - Marginal usefulness, not autofixable.
* `no-shadow` - Marginal usefulness, not autofixable.
* `sort-keys` - This is only a minor style thing, the ESLint rule does not allow grouping, and is not autofixable.