### PR TITLE
Disable no-undef for TypeScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,11 @@ module.exports = {
       },
 
       rules: {
+        // This rule has issues with the TypeScript parser, but tsc catches
+        // these sorts of errors anyway.
+        // See: https://github.com/typescript-eslint/typescript-eslint/issues/342
+        'no-undef': 'off',
+
         // Require overloads to be grouped together
         '@typescript-eslint/adjacent-overload-signatures': 'error',
 


### PR DESCRIPTION
![](https://media2.giphy.com/media/9GI7UlOQ6uU95v82q7/giphy-downsized-medium.gif)

☝️ Actually Tuesdays after Easter weekend

The `no-undef` rule has issues with the TypeScript ESLint parser, but `tsc` should catch these sorts of errors anyway. See https://github.com/typescript-eslint/typescript-eslint/issues/342