### PR TITLE
Relaxed rules for Cypress tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,11 +72,15 @@ module.exports = {
   overrides: [
     // Relax certain rules for tests.
     {
-      files: ['**/*.po.*', '**/*.spec.*', '**/*.test.*'],
+      files: ['./cypress/**', '**/*.po.*', '**/*.spec.*', '**/*.test.*'],
       env: {
         jest: true,
         mocha: true,
       },
+      globals: {
+        cy: 'readable',
+        Cypress: 'readable',
+      }
 
       rules: {
         'no-console': 'off',


### PR DESCRIPTION
![](https://media2.giphy.com/media/3orifbFCTHRHLqOAFi/giphy.gif)

By default Cypress tests go under `./cypress`. The specs _tend_ to end in `.spec.js`, but there are other files in there too that shouldn't have the stricter rules.