### PR TITLE
Turn off no-dupe-class-members for TypeScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,6 +144,10 @@ module.exports = {
       },
 
       rules: {
+        // Checked by TypeScript and creates false positives with class method
+        // overloads.
+        'no-dupe-class-members': 'off',
+
         // This rule has issues with the TypeScript parser, but tsc catches
         // these sorts of errors anyway.
         // See: https://github.com/typescript-eslint/typescript-eslint/issues/342


### PR DESCRIPTION
![](https://media1.giphy.com/media/3o7TKrMVwrdw5RCAuI/giphy.gif)

The TypeScript compiler checks for duplicate members and this creates false positives when overloading class methods.