### PR TITLE
Allow default export for storbook

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -168,7 +168,13 @@ module.exports = {
   overrides: [
     // Relax certain rules for tests.
     {
-      files: ['cypress/**', '**/*.po.*', '**/*.spec.*', '**/*.test.*'],
+      files: [
+        'cypress/**',
+        '**/*.po.*',
+        '**/*.spec.*',
+        '**/*.test.*',
+        '**/*.stories.*',
+      ],
       env: {
         jest: true,
         mocha: true,
@@ -180,6 +186,7 @@ module.exports = {
 
       rules: {
         'no-console': 'off',
+        'import/no-default-export': 'off',
       },
     },
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -166,6 +166,14 @@ module.exports = {
   },
 
   overrides: [
+    // Relax certain rules for storybooks.
+    {
+      files: ['**/*.stories.*'],
+      rules: {
+        'import/no-default-export': 'off',
+      },
+    },
+
     // Relax certain rules for tests.
     {
       files: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -176,13 +176,7 @@ module.exports = {
 
     // Relax certain rules for tests.
     {
-      files: [
-        'cypress/**',
-        '**/*.po.*',
-        '**/*.spec.*',
-        '**/*.test.*',
-        '**/*.stories.*',
-      ],
+      files: ['cypress/**', '**/*.po.*', '**/*.spec.*', '**/*.test.*'],
       env: {
         jest: true,
         mocha: true,
@@ -194,7 +188,6 @@ module.exports = {
 
       rules: {
         'no-console': 'off',
-        'import/no-default-export': 'off',
       },
     },
 


### PR DESCRIPTION
https://storybook.js.org/docs/formats/component-story-format/

> In CSF, stories and component metadata are defined as ES Modules. Every component story file consists of a required **default export** and one or more named exports.

so switch off `import/no-default-export` rule for storybook.


![](https://media2.giphy.com/media/kXh0iiTgYzWzS/giphy.gif)